### PR TITLE
Issue Solution: "Remember Me" Checkbox Permanently Checked

### DIFF
--- a/src/pages/Auth/Auth.jsx
+++ b/src/pages/Auth/Auth.jsx
@@ -418,20 +418,18 @@ function LogIn({ setLogin, handleThemeSwitch = null, currentTheme = "light" }) {
                     </div>
 
                     <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                            <input
-                                id="remember-me"
-                                name="remember-me"
-                                type="checkbox"
-                                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
-                                checked
-                                readOnly
-                            />
-                            <label htmlFor="remember-me" className="ml-2 text-sm text-gray-600 dark:text-gray-300">
-                                Remember me
-                            </label>
-                        </div>
-                    </div>
+    <div className="flex items-center">
+        <input
+            id="remember-me"
+            name="remember-me"
+            type="checkbox"
+            className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+        />
+        <label htmlFor="remember-me" className="ml-2 text-sm text-gray-600 dark:text-gray-300">
+            Remember me
+        </label>
+    </div>
+</div>
 
                     <button
                         type="submit"


### PR DESCRIPTION
issue #152 
In this solution, the checkbox issue was resolved by updating the HTML and removing the problematic attributes that caused it to be permanently checked. Initially, the checked and readOnly attributes were set, which prevented user interaction.

Key Changes:
Removed the checked attribute: This ensured that the checkbox was not permanently checked by default, allowing users to toggle it on or off as needed.
Omitted the readOnly attribute: This allowed the checkbox to be user-interactive, resolving the issue of it being locked in the checked state.